### PR TITLE
Monitor netstandard2.1

### DIFF
--- a/BionicMonitor/BionicMonitor.csproj
+++ b/BionicMonitor/BionicMonitor.csproj
@@ -13,8 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.4" />
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.2.5" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.4.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BionicMonitor/Commands/DocsCommand.cs
+++ b/BionicMonitor/Commands/DocsCommand.cs
@@ -2,7 +2,7 @@ using BionicMonitorService.Utils;
 using McMaster.Extensions.CommandLineUtils;
 
 namespace BionicMonitor.Commands {
-  [Command(Description = "Open Bionic Monitor documentation page in browser")]
+  [Command("docs", Description = "Open Bionic Monitor documentation page in browser")]
   public class DocsCommand : CommandBase {
     protected override int OnExecute(CommandLineApplication app) => OpenBlazorDocs();
 

--- a/BionicMonitor/Commands/UninstallCommand.cs
+++ b/BionicMonitor/Commands/UninstallCommand.cs
@@ -2,7 +2,7 @@ using BionicMonitor.Utils;
 using McMaster.Extensions.CommandLineUtils;
 
 namespace BionicMonitor.Commands {
-  [Command(Description = "Initiate Bionic self-destruct sequence")]
+  [Command("uninstall", Description = "Initiate Bionic self-destruct sequence")]
   public class UninstallCommand : CommandBase {
     protected override int OnExecute(CommandLineApplication app) => UninstallBionic();
 

--- a/BionicMonitor/Commands/UpdateCommand.cs
+++ b/BionicMonitor/Commands/UpdateCommand.cs
@@ -2,7 +2,7 @@ using BionicMonitor.Utils;
 using McMaster.Extensions.CommandLineUtils;
 
 namespace BionicMonitor.Commands {
-  [Command(Description = "Update Bionic Monitor to its latest incarnation")]
+  [Command("update", Description = "Update Bionic Monitor to its latest incarnation")]
   public class UpdateCommand : CommandBase {
     protected override int OnExecute(CommandLineApplication app) => UpdateBionic();
 

--- a/BionicMonitor/Commands/VersionCommand.cs
+++ b/BionicMonitor/Commands/VersionCommand.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 using McMaster.Extensions.CommandLineUtils;
 
 namespace BionicMonitor.Commands {
-  [Command(Description = "Print Bionic Monitor version number")]
+  [Command("version", Description = "Print Bionic Monitor version number")]
   public class VersionCommand : CommandBase {
     protected override int OnExecute(CommandLineApplication app) => PrintVersion();
 

--- a/BionicMonitor/Program.cs
+++ b/BionicMonitor/Program.cs
@@ -9,10 +9,10 @@ using Microsoft.AspNetCore.Hosting;
 
 namespace BionicMonitor {
   [Command(Description = "🤖 Bionic Monitor - Live Reload for Blazor & Bionic projects")]
-  [Subcommand("docs", typeof(DocsCommand))]
-  [Subcommand("uninstall", typeof(UninstallCommand))]
-  [Subcommand("update", typeof(UpdateCommand))]
-  [Subcommand("version", typeof(VersionCommand))]
+  [Subcommand(typeof(DocsCommand))]
+  [Subcommand(typeof(UninstallCommand))]
+  [Subcommand(typeof(UpdateCommand))]
+  [Subcommand(typeof(VersionCommand))]
   public class Program {
     [Option("--bionic", Description =
       "Use Bionic root directory .bionic/wwwroot (will not mess with files in wwwroot)")]

--- a/BionicMonitorService/BionicMonitorService.cs
+++ b/BionicMonitorService/BionicMonitorService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using BionicMonitorService.Hubs;
 using BionicMonitorService.Options;
@@ -38,13 +39,26 @@ namespace BionicMonitorService {
         childAppBuilder.UseSpa(spa => spa.Options.DefaultPageStaticFileOptions = staticFileOptions);
       });
 
-      var distPath = Path.Combine(Directory.GetCurrentDirectory(), "bin/Debug/netstandard2.0/dist");
+      var distPath = Path.Combine(Directory.GetCurrentDirectory(), "bin/Debug/netstandard2.1/dist");
       if (Directory.Exists(distPath)) {
         app.UseStaticFiles(new StaticFileOptions {
           FileProvider = new PhysicalFileProvider(distPath),
           ContentTypeProvider = CreateContentTypeProvider(),
           OnPrepareResponse = SetCacheHeaders
         });
+      }
+      else {
+        distPath = Path.Combine(Directory.GetCurrentDirectory(), "bin/Debug/netstandard2.0/dist");
+        if (Directory.Exists(distPath)) {
+          app.UseStaticFiles(new StaticFileOptions {
+            FileProvider = new PhysicalFileProvider(distPath),
+            ContentTypeProvider = CreateContentTypeProvider(),
+            OnPrepareResponse = SetCacheHeaders
+          });
+        }
+        else {
+          Console.WriteLine($"💀 Bionic Monitor was unable to find a netstandard (2.0 or 2.1) build directory. Please build project and restart Bionic Monitor.");
+        }
       }
 
       app.UseSignalR(routes => routes.MapHub<ReloadHub>("/reloadHub"));


### PR DESCRIPTION
Bionic Monitor will mmonitor netstandard in the following manner:

- If exists, it will monitor netstandard2.1 directory
- Else, if exists it will monitor netstandard2.0 directory
- If none of the above directories exist, it will display an error message

Also updated CLI subcommands to latest API.

Issue #7